### PR TITLE
#151 fixed the bug about locations error on join session screen

### DIFF
--- a/contexts/LocationsContext.js
+++ b/contexts/LocationsContext.js
@@ -13,12 +13,29 @@ export const LocationsProvider = ({ children }) => {
     const fetchLocations = async () => {
       if (user?.uid) {
         try {
+          // Get the current session ID for the user
           const sessionId = await userService.getCurrentSession(user.uid);
-          const raw = await sessionService.listSessionArtifacts(sessionId);
-          //const raw = null;
-          //console.log(raw);
+          // If no sessionId, clear locations and exit
+          if (!sessionId) {
+            setLocations([]);
+            return;
+          }
+          let raw = null;
+          try {
+            // Try to fetch session artifacts (locations) for the session
+            raw = await sessionService.listSessionArtifacts(sessionId);
+          } catch (err) {
+            // If the session does not exist, clear locations and exit
+            if (err.message && err.message.includes('Session not found')) {
+              setLocations([]);
+              return;
+            } else {
+              // For other errors, rethrow
+              throw err;
+            }
+          }
+          // If locations are found, set them; otherwise, clear
           if (raw) {
-            // console.log("setting locations");
             setLocations(
               Object.entries(raw).map(([id, rest]) => ({ id, ...rest }))
             );
@@ -26,9 +43,11 @@ export const LocationsProvider = ({ children }) => {
             setLocations([]);
           }
         } catch (error) {
+          // Log any unexpected errors
           console.error("Error fetching locations from Firebase:", error);
         }
       } else {
+        // If no user, clear locations
         setLocations([]);
       }
     };


### PR DESCRIPTION
I accidentally named the branch about leaderboard, but this is actually a fix for the JoinSession screen! The problem was that when the JoinSession screen loads, Locations Context tries to fetch a bunch of information like the user's sessionID and locations for the artifacts of the session. Since the user is not in a session at the JoinSession screen, the error was being thrown that locations were not found. The fixed code provides more error checking and makes sure to account for the scenarios where the user is not in a session yet by setting the locations to an empty array instead of throwing an error. This prevents the error from showing up on the JoinSession screen.