### PR TITLE
#133 - Leaderboard Screen Fix

### DIFF
--- a/services/SessionService.ts
+++ b/services/SessionService.ts
@@ -314,12 +314,12 @@ export class SessionService extends BaseService {
 
   /**
    
-Gets the leaderboard for a session, ordered by points (I did descending)*
-Returns all participants in the session with their display names and points.
-*
-@param sessionId - Unique identifier for the session
-@returns Array of leaderboard entries with userId, displayName, and points
-@throws Error if the session does not exist*/
+  Gets the leaderboard for a session, ordered by points (I did descending)*
+  Returns all participants in the session with their display names and points.
+  *
+  @param sessionId - Unique identifier for the session
+  @returns Array of leaderboard entries with userId, displayName, and points
+  @throws Error if the session does not exist*/
 
   // Could throw this array block into a type alisas for readability
   async getSessionLeaderboardEntries(

--- a/updated_services/SessionService.ts
+++ b/updated_services/SessionService.ts
@@ -520,4 +520,57 @@ export class SessionService extends BaseService {
       
     });
   }
+
+  /**
+   
+  Gets the leaderboard for a session, ordered by points (I did descending)*
+  Returns all participants in the session with their display names and points.
+  *
+  @param sessionId - Unique identifier for the session
+  @returns Array of leaderboard entries with userId, displayName, and points
+  @throws Error if the session does not exist*/
+
+  // Could throw this array block into a type alisas for readability
+  async getSessionLeaderboardEntries(
+    sessionId: string
+  ): Promise<Array<{ userId: string; displayName: string; points: number }>> {
+    const session = await this.getSession(sessionId);
+    if (!session) throw new Error("Session not found");
+
+    const entries: Array<{
+      userId: string;
+      displayName: string;
+      points: number;
+    }> = [];
+
+    if (session.participants) {
+      for (const userId of Object.keys(session.participants)) {
+        const displayName =
+          (await this.getData<string>(`users/${userId}/displayName`)) ??
+          "Unknown User";
+
+        const points =
+          (await this.getData<number>(
+            `users/${userId}/sessionsJoined/${sessionId}/points`
+          )) ?? 0;
+
+        entries.push({ userId, displayName, points });
+      }
+    }
+
+    // Selection sort — unchanged logic
+    for (let i = 0; i < entries.length - 1; i++) {
+      for (let j = i + 1; j < entries.length; j++) {
+        const a = entries[i];
+        const b = entries[j];
+
+        if (b.points > a.points) {
+          entries[i] = b;
+          entries[j] = a;
+        }
+      }
+    }
+
+    return entries;
+  }
 }


### PR DESCRIPTION
The issue I saw was with the SessionService files. The code to get the session's leaderboard entries was referencing the updated_services files, but it did not have the correct function to handle the leaderboard entries. I copied over the function from services/SessionService.ts into updated_services/SessionService.ts, and it seemed to work.